### PR TITLE
Remove href from link for Bootstrap 3

### DIFF
--- a/template/bootstrap3/links.twig
+++ b/template/bootstrap3/links.twig
@@ -12,7 +12,7 @@
 		{% set disabled = true %}
 	{% endif %}
 	<li class="{% if link.active %}active{% endif %}{% if disabled %} disabled{% endif %}">
-		<a href="{{ link.url }}" class="skeleton-pager-link">
+		<a{% if disabled == false %} href="{{ link.url }}"{% endif %} class="skeleton-pager-link">
 			{% if link.page == 'previous' %}
 				&laquo;
 			{% elseif link.page == 'next' %}


### PR DESCRIPTION
Remove href from link for Bootstrap 3.  Without that, the mouse pointer shows forbidden, but link is still clickable.