### PR TITLE
fix hash extra conditions for joins

### DIFF
--- a/lib/Skeleton/Pager/Pager.php
+++ b/lib/Skeleton/Pager/Pager.php
@@ -452,8 +452,11 @@ class Pager {
 
 		if (isset($options['joins']) and is_array($options['joins'])) {
 			$joins = [];
-			foreach ($options['joins'] as $join) {
-				$joins[] = new Join($join['remote_table'], $join['remote_id'], $join['local_field'], $join['conditions']);
+			foreach ($options['joins'] as $join_key => $join) {
+				$joins[$join_key] = new Join($join['remote_table'], $join['remote_id'], $join['local_field']);
+				foreach ($join['conditions'] as $condition) {
+					$joins[$join_key]->add_condition(new Condition($condition['local_field'], $condition['comparison'], $condition['value']));
+				}
 			}
 
 			$options['joins'] = $joins;
@@ -488,6 +491,10 @@ class Pager {
 			$direction = $this->options['direction'];
 		}
 
+		if ($joins === null) {
+			$joins = $this->options['joins'];
+		}
+
 		if ($per_page === null) {
 			$per_page = $this->options['per_page'];
 		}
@@ -512,13 +519,21 @@ class Pager {
 			$flat_conditions = $conditions;
 		}
 
-		$joins = [];
-		foreach ($this->options['joins'] as $join) {
-			$joins[] = [
+		$flat_joins = [];
+		foreach ($joins as $join) {
+			$extra_conditions = [];
+			foreach ($join->get_conditions() as $condition) {
+				$extra_conditions[] = [
+					'local_field' => $condition->get_local_field(),
+					'value' => $condition->get_value(),
+					'comparison' => $condition->get_comparison(),
+				];
+			}
+			$flat_joins[] = [
 				'remote_table' => $join->get_remote_table(),
 				'remote_id' => $join->get_remote_id(),
 				'local_field' => $join->get_local_field(),
-				'conditions' => $join->get_conditions(),
+				'conditions' => $extra_conditions,
 			];
 		}
 
@@ -528,7 +543,7 @@ class Pager {
 			'page' => $page,
 			'sort' => $sort,
 			'direction' => $direction,
-			'joins' => $joins,
+			'joins' => $flat_joins,
 			'per_page' => $per_page,
 		];
 


### PR DESCRIPTION
correct hash saving join extra condition
now if we use "get_options_from_hash" we return join without extra conditions
```
$pager = new Pager('order_item');
$condition = new \Skeleton\Pager\Sql\Condition('product.classname', '=', \Product_Ticket::class);
$pager->add_join('product', 'order_item_id', 'order_item.id', $condition);
$pager->page();

$hash = $pager->create_options_hash();
$pager2 = \Skeleton\Pager\Pager::get_by_options_hash($hash);
$pager2->page();
```
$pager and $pager2 will have different results because $pager2 will be without the condition "'product.classname', '=', \Product_Ticket::class", which is an extra join condition